### PR TITLE
Add JWT auth to protect write endpoints

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -7,8 +7,6 @@ const authRoute = require("./routes/auth");
 const userRoute = require("./routes/users");
 const postRoute = require("./routes/posts");
 const categoryRoute = require("./routes/categories");
-const multer = require("multer");
-const path = require("path");
 const cors = require("cors");
 
 dotenv.config();
@@ -44,21 +42,6 @@ mongoose
   })
   .then(() => console.log("Connected to MongoDB"))
   .catch((err) => console.log(err));
-
-// Multer 檔案上傳設定
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, "images");
-  },
-  filename: (req, file, cb) => {
-    cb(null, req.body.name);
-  },
-});
-
-const upload = multer({ storage: storage });
-app.post("/api/upload", upload.single("file"), (req, res) => {
-  res.status(200).json("File has been uploaded");
-});
 
 // 路由設定
 app.use("/api/auth", authRoute);

--- a/api/middleware/verifyToken.js
+++ b/api/middleware/verifyToken.js
@@ -1,0 +1,24 @@
+const jwt = require("jsonwebtoken");
+
+// 驗證請求是否帶有合法的 JWT。通過後將 payload 掛到 req.user。
+function verifyToken(req, res, next) {
+  const authHeader = req.headers.authorization || req.headers.Authorization;
+  const token =
+    authHeader && authHeader.startsWith("Bearer ")
+      ? authHeader.split(" ")[1]
+      : null;
+
+  if (!token) {
+    return res.status(401).json("You are not authenticated!");
+  }
+
+  jwt.verify(token, process.env.JWT_SECRET, (err, payload) => {
+    if (err) {
+      return res.status(403).json("Token is not valid!");
+    }
+    req.user = payload; // { id, username }
+    next();
+  });
+}
+
+module.exports = verifyToken;

--- a/api/package.json
+++ b/api/package.json
@@ -5,8 +5,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.2",
     "express": "^4.18.1",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^6.6.2",
-    "multer": "^1.4.5-lts.1",
     "nodemon": "^2.0.20",
     "path": "^0.12.7"
   },

--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -1,9 +1,11 @@
 const router = require("express").Router();
 const User = require("../models/User");
 const bcrypt = require('bcrypt');
+const jwt = require("jsonwebtoken");
+const verifyToken = require("../middleware/verifyToken");
 
-//REGISTER
-router.post("/5j4hk4", async (req,res)=>{
+//REGISTER（需登入才能建立新帳號 — 防止任何人從公開端點自行註冊）
+router.post("/5j4hk4", verifyToken, async (req,res)=>{
     try{
 
         const salt = await bcrypt.genSalt(10);
@@ -15,7 +17,8 @@ router.post("/5j4hk4", async (req,res)=>{
         });
 
         const user = await newUser.save();
-        res.status(200).json(user)
+        const {password, ...others} = user._doc;
+        res.status(200).json(others)
     } catch(err){
         res.status(500).json(err);
     }
@@ -36,9 +39,15 @@ router.post("/login", async (req,res)=>{
             return res.status(400).json("Wrong credentials");
         }
 
+        const token = jwt.sign(
+            { id: user._id, username: user.username },
+            process.env.JWT_SECRET,
+            { expiresIn: "7d" }
+        );
+
         const {password, ...others} = user._doc;
 
-        res.status(200).json(others);
+        res.status(200).json({ ...others, token });
     }catch (err){
         res.status(500).json(err);
     }

--- a/api/routes/posts.js
+++ b/api/routes/posts.js
@@ -1,10 +1,12 @@
 const router = require("express").Router();
 const User = require("../models/User");
 const Post = require("../models/Post");
+const verifyToken = require("../middleware/verifyToken");
 
 //CREATE POST
-router.post("/", async (req,res)=>{
-   const newPost = new Post(req.body);
+router.post("/", verifyToken, async (req,res)=>{
+   // 作者一律取自 token，忽略 client 傳來的 username，避免冒名發文
+   const newPost = new Post({ ...req.body, username: req.user.username });
    try{
         const savedPost = await newPost.save();
         res.status(200).json(savedPost);
@@ -15,10 +17,10 @@ router.post("/", async (req,res)=>{
 });
 
 //UPDATE POST
-router.put("/:id", async (req,res)=>{
+router.put("/:id", verifyToken, async (req,res)=>{
     try{
         const post = await Post.findById(req.params.id);
-        if(post.username === req.body.username){
+        if(post.username === req.user.username){
             try{
                 const updatedPost = await Post.findByIdAndUpdate(
                     req.params.id,
@@ -40,10 +42,10 @@ router.put("/:id", async (req,res)=>{
 });
 
 //DELETE POST
-router.delete("/:id", async (req,res)=>{
+router.delete("/:id", verifyToken, async (req,res)=>{
     try{
         const post = await Post.findById(req.params.id);
-        if(post.username === req.body.username){
+        if(post.username === req.user.username){
             try{
                 await post.delete();
                 res.status(200).json("Post has been deleted...");

--- a/api/routes/users.js
+++ b/api/routes/users.js
@@ -2,23 +2,30 @@ const router = require("express").Router();
 const User = require("../models/User");
 const Post = require("../models/Post");
 const bcrypt = require("bcrypt");
+const verifyToken = require("../middleware/verifyToken");
 
 //UPDATE
-router.put("/:id", async (req,res)=>{
-    if(req.body.userId === req.params.id){
+router.put("/:id", verifyToken, async (req,res)=>{
+    if(req.user.id === req.params.id){
+        // 只更新有提供且非空的欄位，避免空字串覆蓋既有資料（含密碼）
+        const updates = {};
+        if(req.body.username) updates.username = req.body.username;
+        if(req.body.email) updates.email = req.body.email;
+        if(req.body.profilePic) updates.profilePic = req.body.profilePic;
         if(req.body.password){
             const salt = await bcrypt.genSalt(10);
-            req.body.password = await bcrypt.hash(req.body.password, salt);
+            updates.password = await bcrypt.hash(req.body.password, salt);
         }
         try{
             const updatedUser = await User.findByIdAndUpdate(
                 req.params.id,
             {
-                $set: req.body,
+                $set: updates,
             },
             {new:true}
         );
-            res.status(200).json(updatedUser);
+            const {password, ...others} = updatedUser._doc;
+            res.status(200).json(others);
         } catch(err){
             res.status(500).json(err);
         }
@@ -28,17 +35,14 @@ router.put("/:id", async (req,res)=>{
 });
 
 //DELETE
-router.delete("/:id", async (req,res)=>{
-    console.log(req.body.userId);
-    console.log(req.params.id);
-    if(req.body.userId === req.params.id){
+router.delete("/:id", verifyToken, async (req,res)=>{
+    if(req.user.id === req.params.id){
         try{
             const user = await User.findById(req.params.id);
             try{
                 await Post.deleteMany({username:user.username});
                 await User.findByIdAndDelete(req.params.id)
                 res.status(200).json("User has been deleted...");
-                res.status(200).json(updatedUser);
             } catch(err){
                 res.status(500).json(err);
             }

--- a/react-blog/src/pages/settings/Settings.jsx
+++ b/react-blog/src/pages/settings/Settings.jsx
@@ -12,7 +12,6 @@ export default function Settings() {
     const [password, setPassword] = useState("");
     const [success, setSuccess] = useState(false);
     const {user, dispatch} = useContext(Context);
-    const upload = process.env.REACT_APP_BACKEND_URL + "/api/upload"
     const baseURL = process.env.REACT_APP_BACKEND_URL + "/api/users/"
 
     const handleSubmit = async(e) =>{
@@ -26,30 +25,19 @@ export default function Settings() {
         };
 
         if(file){
-            // const data =  new FormData();
-            // const filename = Date.now() + file.name;
-            // data.append("name", filename);
-            // data.append("file", file);
-            // updatedUser.profilePic = filename;
-            // try{
-            //     await axios.post("https://oroblog.herokuapp.com/api/upload",data);
-            // }catch(err){}
-            const data =  new FormData();
-            var reader = new FileReader();
-            reader.readAsDataURL(file);
-            reader.onload = function(e){
-                var imgcode = e.target.result;
-                console.log(imgcode);
-                updatedUser.profilePic = imgcode;
-                data.append("file",imgcode);
-            }
-            try{
-                // await axios.post("/upload", data);
-                await axios.post(upload,data);
-            }catch(err){}
+            // 頭像以 base64 data URL 直接存進使用者資料
+            const imgcode = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = (e) => resolve(e.target.result);
+                reader.onerror = reject;
+                reader.readAsDataURL(file);
+            });
+            updatedUser.profilePic = imgcode;
         }
         try {
-            const res = await axios.put(baseURL +user._id, updatedUser);
+            const res = await axios.put(baseURL +user._id, updatedUser,{
+                headers: { Authorization: "Bearer " + user.token },
+            });
             setSuccess(true);
             dispatch({type:"UPDATE_SUCCESS", payload:res.data});
         } catch (error) {
@@ -60,6 +48,7 @@ export default function Settings() {
     const handleDelete = async() => {
         try {
           await axios.delete(baseURL + user._id, {
+            headers: { Authorization: "Bearer " + user.token },
             data:{username:user.username},
         });
           window.location.replace("/");

--- a/react-blog/src/pages/write/Write.jsx
+++ b/react-blog/src/pages/write/Write.jsx
@@ -72,7 +72,9 @@ export default function Write() {
             // }catch(err){}
         }
         try {
-            const res = await axios.post(baseURL,newPost);
+            const res = await axios.post(baseURL,newPost,{
+                headers: { Authorization: "Bearer " + user.token },
+            });
             // const res = await axios.post("/posts",newPost);
             // await new Promise(resolve => setTimeout(resolve, 10000));
             window.location.replace("/post/"+res.data._id);


### PR DESCRIPTION
Replace the trust-the-client authorization model with verified JWT identity. Previously posts/users write endpoints were unauthenticated or authorized by client-supplied username/userId, letting anyone create/edit/delete any post or account.

- add verifyToken middleware (verifies Bearer JWT, sets req.user)
- issue JWT on login; require auth on register endpoint
- gate posts create/update/delete; take author from token, not body
- gate users update/delete; compare req.user.id; stop empty fields overwriting existing data; drop stray undefined-var line
- remove dead, vulnerable /api/upload route (no auth + path traversal)
- send Authorization header from Write/Settings; fix profilePic race

Requires JWT_SECRET env var on the backend. Frontend and backend must deploy together; existing sessions must re-login to obtain a token.